### PR TITLE
Fix 500 error on review page

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="../.astro/types.d.ts" />
+/// <reference types="@astrojs/cloudflare" />
 
 interface ImportMetaEnv {
   readonly ANTHROPIC_API_KEY: string;
@@ -7,6 +8,15 @@ interface ImportMetaEnv {
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
+}
+
+type Runtime = import('@astrojs/cloudflare').Runtime<{
+  ANTHROPIC_API_KEY: string;
+  ANTHROPIC_MODEL?: string;
+}>;
+
+declare namespace App {
+  interface Locals extends Runtime {}
 }
 
 // Form attributes (legacy - kept for compatibility)

--- a/src/pages/api/okr-reviewer.ts
+++ b/src/pages/api/okr-reviewer.ts
@@ -51,7 +51,7 @@ interface AnthropicErrorResponse {
   };
 }
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
   try {
     const { input } = await request.json();
 
@@ -62,9 +62,15 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    const apiKey = import.meta.env.ANTHROPIC_API_KEY;
-    const model = import.meta.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4-5-20250929';
+    // Access environment variables from Cloudflare runtime
+    // In Cloudflare Pages, secrets are accessed via locals.runtime.env
+    const cloudflareEnv = (locals as App.Locals).runtime?.env;
+    const apiKey = cloudflareEnv?.ANTHROPIC_API_KEY || import.meta.env.ANTHROPIC_API_KEY;
+    const model = cloudflareEnv?.ANTHROPIC_MODEL || import.meta.env.ANTHROPIC_MODEL || 'claude-sonnet-4-5-20250929';
 
+    console.log('Cloudflare env available:', !!cloudflareEnv);
+    console.log('API Key from Cloudflare:', !!cloudflareEnv?.ANTHROPIC_API_KEY);
+    console.log('API Key from import.meta.env:', !!import.meta.env.ANTHROPIC_API_KEY);
     console.log('API Key present:', !!apiKey);
     console.log('Model:', model);
 


### PR DESCRIPTION
The ANTHROPIC_API_KEY was not accessible because import.meta.env only works for build-time variables. In Cloudflare Pages, runtime secrets must be accessed via locals.runtime.env from the Astro Cloudflare adapter.