### PR TITLE
Fix okr-sjekken 405 error and URL migration

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="astro/client" />
+/// <reference path="integrations/_inox-tools_astro-when/types.d.ts" />
 /// <reference path="astro/content.d.ts" />

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,11 +1,13 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 import react from '@astrojs/react';
+import cloudflare from '@astrojs/cloudflare';
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [tailwind(), react()],
-  output: 'static',
+  output: 'hybrid',
+  adapter: cloudflare(),
   site: 'https://fyrk.no'
 });
 


### PR DESCRIPTION
- Add @astrojs/cloudflare adapter to astro.config.mjs
- Change output from 'static' to 'hybrid' to support API routes
- Fixes 405 Method Not Allowed error on /api/okr-reviewer

The static build mode doesn't support API endpoints since there's no server to process POST requests. Hybrid mode allows static pages to be pre-rendered while API routes run on Cloudflare Pages Functions.