### PR TITLE
Fix OKR paste issue on iPhone browsers

### DIFF
--- a/src/components/OKRReviewer.tsx
+++ b/src/components/OKRReviewer.tsx
@@ -230,7 +230,13 @@ export default function OKRReviewer() {
           id="okr-input"
           value={input}
           onChange={(e) => {
-            setInput(e.target.value);
+            let newValue = e.target.value;
+            // Fallback: decode URL-encoded text on change
+            // This handles cases where paste event prevention doesn't work (iOS Safari/Chrome)
+            if (isUrlEncoded(newValue)) {
+              newValue = safeDecodeURIComponent(newValue);
+            }
+            setInput(newValue);
             if (error) setError(null);
           }}
           onPaste={handlePaste}


### PR DESCRIPTION
The previous paste event handler fix doesn't work reliably on all iOS browsers. On some versions of iOS Safari/Chrome, e.preventDefault() doesn't fully prevent the native paste, and the URL-encoded text still ends up in the textarea through the onChange handler.

This adds a fallback check in onChange to decode URL-encoded text, ensuring pasted OKR text is always readable regardless of browser behavior.