### PR TITLE
Fix smoke tests to match actual site structure

### DIFF
--- a/src/components/landing/LandingFooter.astro
+++ b/src/components/landing/LandingFooter.astro
@@ -17,7 +17,7 @@ interface Props {
 const { address, orgNumber, emailHref, emailLabel, linkedinHref, linkedinLabel } = Astro.props;
 ---
 
-<footer class="py-10 px-6 border-t border-neutral-200 bg-neutral-50 relative overflow-hidden">
+<footer class="py-10 px-6 border-t border-neutral-200 bg-neutral-50 relative overflow-hidden" role="contentinfo">
   <!-- Subtle diagonal FYRK signature element -->
   <div class="absolute inset-0 pointer-events-none">
     <div class="absolute -right-1/4 -bottom-1/2 w-[500px] h-[250px] bg-gradient-to-tl from-brand-navy/[0.04] to-transparent rotate-[-25deg] rounded-[80px]"></div>

--- a/tests/contact.smoke.ts
+++ b/tests/contact.smoke.ts
@@ -1,41 +1,27 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Contact Page Smoke Tests', () => {
-  test('contact page loads correctly', async ({ page }) => {
-    await page.goto('/kontakt');
-    await expect(page).toHaveTitle(/Kontakt/);
-    await expect(page.getByRole('heading', { level: 1, name: /Kontakt/i })).toBeVisible();
+test.describe('Contact Section Smoke Tests', () => {
+  test('homepage contact section is accessible', async ({ page }) => {
+    await page.goto('/#kontakt');
+
+    // Check the contact section heading
+    await expect(page.getByRole('heading', { name: /Ta kontakt/i })).toBeVisible();
   });
 
-  test('contact form is accessible and has required fields', async ({ page }) => {
-    await page.goto('/kontakt');
-    
-    const form = page.locator('form');
-    await expect(form).toBeVisible();
+  test('contact section has email link', async ({ page }) => {
+    await page.goto('/#kontakt');
 
-    // Check required fields
-    const nameField = page.getByLabel(/Navn/i);
-    await expect(nameField).toBeVisible();
-    await expect(nameField).toHaveAttribute('required');
-
-    const emailField = page.getByLabel(/E-post/i);
-    await expect(emailField).toBeVisible();
-    await expect(emailField).toHaveAttribute('required');
-    await expect(emailField).toHaveAttribute('type', 'email');
-
-    const messageField = page.getByLabel(/Melding/i);
-    await expect(messageField).toBeVisible();
-    await expect(messageField).toHaveAttribute('required');
-
-    const consentCheckbox = page.getByLabel(/samtykker/i);
-    await expect(consentCheckbox).toBeVisible();
-    await expect(consentCheckbox).toHaveAttribute('required');
+    const emailLink = page.getByRole('link', { name: /hei@fyrk\.no/i });
+    await expect(emailLink).toBeVisible();
+    await expect(emailLink).toHaveAttribute('href', 'mailto:hei@fyrk.no');
   });
 
-  test('form submission button is visible', async ({ page }) => {
-    await page.goto('/kontakt');
-    const submitButton = page.getByRole('button', { name: /Send melding/i });
-    await expect(submitButton).toBeVisible();
+  test('contact section has LinkedIn link', async ({ page }) => {
+    await page.goto('/#kontakt');
+
+    const linkedinLink = page.getByRole('link', { name: /LinkedIn/i }).first();
+    await expect(linkedinLink).toBeVisible();
+    await expect(linkedinLink).toHaveAttribute('target', '_blank');
   });
 });
 

--- a/tests/pages.smoke.ts
+++ b/tests/pages.smoke.ts
@@ -1,31 +1,32 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('All Pages Smoke Tests', () => {
-  const pages = [
-    { path: '/', title: /Fyrk/ },
-    { path: '/om', title: /Om oss/ },
-    { path: '/kontakt', title: /Kontakt/ },
-    { path: '/blogg', title: /Blogg/ },
-  ];
+  test('homepage loads correctly', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/Fyrk/);
+    await expect(page.locator('main')).toBeVisible();
+    await expect(page.locator('nav')).toBeVisible();
+    await expect(page.getByRole('contentinfo')).toBeVisible();
+  });
 
-  for (const pageInfo of pages) {
-    test(`${pageInfo.path} loads correctly`, async ({ page }) => {
-      await page.goto(pageInfo.path);
-      await expect(page).toHaveTitle(pageInfo.title);
-      await expect(page.locator('main')).toBeVisible();
-      await expect(page.locator('nav')).toBeVisible();
-      await expect(page.getByRole('contentinfo')).toBeVisible();
-    });
-  }
+  test('OKR-sjekken page loads correctly', async ({ page }) => {
+    await page.goto('/okr-sjekken');
+    await expect(page).toHaveTitle(/OKR/);
+    await expect(page.locator('main')).toBeVisible();
+    // OKR page has a heading instead of nav
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+  });
 
-  test('all pages have accessible navigation', async ({ page }) => {
-    const pages = ['/', '/om', '/kontakt', '/blogg'];
-    
-    for (const path of pages) {
-      await page.goto(path);
-      const skipLink = page.getByRole('link', { name: /Hopp til hovedinnhold/i });
-      await expect(skipLink).toBeVisible();
-    }
+  test('homepage has accessible navigation', async ({ page }) => {
+    await page.goto('/');
+    const skipLink = page.getByRole('link', { name: /Hopp til hovedinnhold/i });
+    await expect(skipLink).toBeVisible();
+  });
+
+  test('OKR-sjekken has accessible navigation', async ({ page }) => {
+    await page.goto('/okr-sjekken');
+    const skipLink = page.getByRole('link', { name: /Hopp til hovedinnhold/i });
+    await expect(skipLink).toBeVisible();
   });
 });
 


### PR DESCRIPTION
- Add role="contentinfo" to LandingFooter for accessibility compliance
- Update pages.smoke.ts to test existing pages (/, /okr-sjekken) instead of non-existent pages (/om, /kontakt, /blogg)
- Update contact.smoke.ts to test homepage contact section instead of non-existent /kontakt page

The smoke tests were failing because they tested for pages that don't exist in the actual site structure.