### PR TITLE
Skip API tests when running against GitHub Pages

### DIFF
--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -255,9 +255,11 @@ Når du endrer en side, oppdater tilhørende smoke tests:
 |---------|---------------------|-----------------|
 | `pages.smoke.ts` | `/`, `/okr-sjekken` | `main`, `nav`, `h1`, skip-link |
 | `contact.smoke.ts` | `/#kontakt` | `h2`, e-postlenke, LinkedIn-lenke |
-| `error-pages.smoke.ts` | 404/500-sider | `lang="no"`, dark mode, redirect |
+| `error-pages.smoke.ts` | 404/500-sider | `lang="no"`, dark mode, redirect, API* |
 | `mobile.ux.ts` | `/`, `/okr-sjekken` | Touch targets (48px), tekststr., `textarea` |
 | `contrast.spec.ts` | `/`, `/okr-sjekken` | `.card`, `textarea`, `.btn-primary` |
+
+\* **Merk:** API-tester i `error-pages.smoke.ts` hoppes over når testene kjøres mot produksjon (fyrk.no) siden API-rutene kun er tilgjengelige via Cloudflare Workers, ikke GitHub Pages.
 
 ### Kjør smoke tests lokalt før push
 

--- a/tests/error-pages.smoke.ts
+++ b/tests/error-pages.smoke.ts
@@ -98,7 +98,15 @@ test.describe('Error Pages Smoke Tests', () => {
     });
   });
 
+  // Skip API tests when running against production (GitHub Pages)
+  // since API routes are only available on Cloudflare Workers
+  const isProduction = process.env.PLAYWRIGHT_TEST_BASE_URL?.includes('fyrk.no');
+
   test.describe('API Error Handling', () => {
+    test.beforeEach(async ({}, testInfo) => {
+      testInfo.skip(isProduction === true, 'API routes not available on GitHub Pages');
+    });
+
     test('should return JSON error for invalid API request', async ({ request }) => {
       const response = await request.post('/api/okr-sjekken', {
         data: {},


### PR DESCRIPTION
API routes (/api/okr-sjekken) are only available on Cloudflare Workers, not on GitHub Pages which only serves static files. This was causing the daily smoke tests to fail since they POST to the API endpoint.

- Add beforeEach hook to skip API tests when PLAYWRIGHT_TEST_BASE_URL contains 'fyrk.no' (production)
- Update TESTING.md to document this behavior