### PR TITLE
Debug information overload issue

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -89,7 +89,7 @@ export const ANTHROPIC_CONFIG = {
   /** Default model */
   DEFAULT_MODEL: 'claude-sonnet-4-5-20250929',
   /** Max tokens for response */
-  MAX_TOKENS: 1500,
+  MAX_TOKENS: 4096,
   /** Request timeout in milliseconds */
   REQUEST_TIMEOUT_MS: 30000,
 } as const;


### PR DESCRIPTION
The JSON response format requires extensive content across multiple fields (fase, observasjoner, styringsmønstre, refleksjon, meta). 1500 tokens was insufficient, causing incomplete responses and automatic retries that still failed.