### PR TITLE
Transform statistics page into analytics dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "@astrojs/react": "^4.0.0",
         "@fontsource/inter": "^5.2.8",
         "astro": "^4.0.0",
+        "lucide-react": "^0.562.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "recharts": "^3.6.0"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.6",
@@ -2820,6 +2822,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
+      "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -3233,7 +3271,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -3292,6 +3335,69 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/debug": {
@@ -3383,6 +3489,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
@@ -4544,6 +4656,127 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
@@ -4566,6 +4799,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -4763,6 +5002,16 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.43.0.tgz",
+      "integrity": "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -5464,6 +5713,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -5479,6 +5738,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
@@ -5961,6 +6229,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.562.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
+      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {
@@ -7635,6 +7912,36 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
+      "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -7694,6 +8001,51 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.6.0.tgz",
+      "integrity": "sha512-L5bjxvQRAe26RlToBAziKUB7whaGKEwD3znoM6fz3DrTowCIC/FnJYnuq1GEzB8Zv2kdTfaxQfi5GoH0tBinyg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/regex": {
@@ -7889,6 +8241,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -8969,6 +9327,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9016,6 +9383,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
     "@astrojs/react": "^4.0.0",
     "@fontsource/inter": "^5.2.8",
     "astro": "^4.0.0",
+    "lucide-react": "^0.562.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "recharts": "^3.6.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",

--- a/src/components/dashboard/AnalyticsDashboard.tsx
+++ b/src/components/dashboard/AnalyticsDashboard.tsx
@@ -1,0 +1,139 @@
+import { MousePointer, Eye, Zap, BarChart3, ExternalLink, Sparkles } from 'lucide-react';
+import { KPICard } from './KPICard';
+import { TrafficChart } from './TrafficChart';
+import { ButtonClickList } from './ButtonClickList';
+
+interface ButtonCount {
+  count: number;
+  label: string;
+}
+
+interface PageStat {
+  label: string;
+  totalViews: number;
+  totalVisitors: number;
+  todayVisitors: number;
+}
+
+interface AnalyticsDashboardProps {
+  buttonCounts: Record<string, ButtonCount>;
+  pageStats: Record<string, PageStat>;
+  totalClicks: number;
+  refreshToken: string;
+}
+
+const OKR_BUTTONS = ['okr_submit', 'okr_example', 'okr_reset', 'okr_privacy_toggle', 'okr_copy_suggestion', 'okr_read_more'];
+const LANDING_BUTTONS = ['hero_cta', 'tools_okr_cta', 'contact_email', 'contact_linkedin', 'about_linkedin'];
+
+export function AnalyticsDashboard({ buttonCounts, pageStats, totalClicks, refreshToken }: AnalyticsDashboardProps) {
+  const totalViews = Object.values(pageStats).reduce((sum, p) => sum + p.totalViews, 0);
+  const totalVisitors = Object.values(pageStats).reduce((sum, p) => sum + p.totalVisitors, 0);
+  const todayVisitors = Object.values(pageStats).reduce((sum, p) => sum + p.todayVisitors, 0);
+
+  const okrButtonData = OKR_BUTTONS.map(id => ({
+    id,
+    label: buttonCounts[id]?.label || id,
+    count: buttonCounts[id]?.count || 0,
+  }));
+
+  const landingButtonData = LANDING_BUTTONS.map(id => ({
+    id,
+    label: buttonCounts[id]?.label || id,
+    count: buttonCounts[id]?.count || 0,
+  }));
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* Header */}
+      <header className="bg-white border-b border-slate-200 sticky top-0 z-10">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-indigo-100 rounded-xl">
+                <BarChart3 className="w-6 h-6 text-indigo-600" />
+              </div>
+              <div>
+                <h1 className="text-xl font-bold text-slate-900">FYRK Analytics</h1>
+                <p className="text-sm text-slate-500">Klikk og besøksstatistikk</p>
+              </div>
+            </div>
+            <a
+              href={`/stats?token=${refreshToken}`}
+              className="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 hover:bg-slate-200 text-slate-700 rounded-lg text-sm font-medium transition-colors"
+            >
+              <Sparkles className="w-4 h-4" />
+              Oppdater
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+        {/* KPI Cards */}
+        <section>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <KPICard
+              title="Totalt knappeklikk"
+              value={totalClicks}
+              icon={<MousePointer className="w-5 h-5" />}
+              variant="primary"
+            />
+            <KPICard
+              title="Totale sidevisninger"
+              value={totalViews}
+              icon={<Eye className="w-5 h-5" />}
+            />
+            <KPICard
+              title="Unike besøkende"
+              value={totalVisitors}
+              icon={<Zap className="w-5 h-5" />}
+            />
+            <KPICard
+              title="Besøkende i dag"
+              value={todayVisitors}
+              icon={<Sparkles className="w-5 h-5" />}
+            />
+          </div>
+        </section>
+
+        {/* Traffic Charts */}
+        <section>
+          <h2 className="text-lg font-semibold text-slate-900 mb-4 flex items-center gap-2">
+            <Eye className="w-5 h-5 text-slate-400" />
+            Sidetrafikk
+          </h2>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {Object.entries(pageStats).map(([pageId, stats]) => (
+              <TrafficChart key={pageId} pageId={pageId} stats={stats} />
+            ))}
+          </div>
+        </section>
+
+        {/* Button Click Lists */}
+        <section>
+          <h2 className="text-lg font-semibold text-slate-900 mb-4 flex items-center gap-2">
+            <MousePointer className="w-5 h-5 text-slate-400" />
+            Knappeklikk
+          </h2>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <ButtonClickList
+              title="OKR-sjekken"
+              buttons={okrButtonData}
+              icon={<Zap className="w-5 h-5" />}
+            />
+            <ButtonClickList
+              title="Landingsside"
+              buttons={landingButtonData}
+              icon={<ExternalLink className="w-5 h-5" />}
+            />
+          </div>
+        </section>
+
+        {/* Footer */}
+        <footer className="text-center text-sm text-slate-400 pt-8 pb-4">
+          Sist oppdatert: {new Date().toLocaleString('no-NO')}
+        </footer>
+      </main>
+    </div>
+  );
+}

--- a/src/components/dashboard/ButtonClickList.tsx
+++ b/src/components/dashboard/ButtonClickList.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect, useCallback } from 'react';
+import { MousePointer, ChevronDown, ChevronUp } from 'lucide-react';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+interface ButtonData {
+  id: string;
+  label: string;
+  count: number;
+}
+
+interface ButtonClickListProps {
+  title: string;
+  buttons: ButtonData[];
+  icon?: React.ReactNode;
+}
+
+type Period = '24h' | 'week' | 'month' | 'year';
+
+interface TimeseriesPoint {
+  label: string;
+  value: number;
+}
+
+const PERIOD_OPTIONS: { value: Period; label: string }[] = [
+  { value: '24h', label: '24t' },
+  { value: 'week', label: 'Uke' },
+  { value: 'month', label: 'Måned' },
+  { value: 'year', label: 'År' },
+];
+
+function ButtonRow({ button, maxCount }: { button: ButtonData; maxCount: number }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [period, setPeriod] = useState<Period>('week');
+  const [chartData, setChartData] = useState<TimeseriesPoint[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const percentage = maxCount > 0 ? (button.count / maxCount) * 100 : 0;
+
+  const fetchChartData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/track?timeseries=true&buttonId=${button.id}&period=${period}`);
+      const result = await response.json();
+      if (result.timeseries) {
+        setChartData(result.timeseries);
+      }
+    } catch (error) {
+      console.error('Error fetching chart data:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [button.id, period]);
+
+  useEffect(() => {
+    if (isExpanded) {
+      fetchChartData();
+    }
+  }, [isExpanded, fetchChartData]);
+
+  const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: Array<{ value: number }>; label?: string }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white border border-slate-200 rounded-lg shadow-lg px-3 py-2">
+          <p className="text-xs text-slate-500 mb-1">{label}</p>
+          <p className="text-sm font-semibold text-slate-900">{payload[0].value} klikk</p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="group">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full relative overflow-hidden rounded-xl transition-all hover:shadow-sm"
+      >
+        <div
+          className="absolute inset-0 bg-gradient-to-r from-indigo-100 to-indigo-50 transition-all"
+          style={{ width: `${percentage}%` }}
+        />
+        <div className="relative flex items-center justify-between px-4 py-3">
+          <div className="flex items-center gap-3">
+            <MousePointer className="w-4 h-4 text-indigo-500" />
+            <span className="font-medium text-slate-700 text-left">{button.label}</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className={`font-bold text-lg ${button.count === 0 ? 'text-slate-300' : 'text-slate-900'}`}>
+              {button.count}
+            </span>
+            {isExpanded ? (
+              <ChevronUp className="w-4 h-4 text-slate-400" />
+            ) : (
+              <ChevronDown className="w-4 h-4 text-slate-400" />
+            )}
+          </div>
+        </div>
+      </button>
+
+      {isExpanded && (
+        <div className="mt-2 bg-slate-50 rounded-xl p-4">
+          <div className="flex justify-end mb-3">
+            <div className="flex gap-1 bg-white rounded-lg p-1 shadow-sm">
+              {PERIOD_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  onClick={() => setPeriod(option.value)}
+                  className={`px-2.5 py-1 text-xs font-medium rounded-md transition-all ${
+                    period === option.value
+                      ? 'bg-indigo-600 text-white'
+                      : 'text-slate-500 hover:text-slate-700'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="h-24">
+            {loading ? (
+              <div className="h-full flex items-center justify-center text-slate-400">
+                <div className="animate-pulse text-sm">Laster...</div>
+              </div>
+            ) : chartData.length === 0 ? (
+              <div className="h-full flex items-center justify-center text-slate-400 text-sm">
+                Ingen data ennå
+              </div>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={chartData} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
+                  <defs>
+                    <linearGradient id={`btn-gradient-${button.id}`} x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="#6366f1" stopOpacity={0.3} />
+                      <stop offset="100%" stopColor="#6366f1" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <XAxis
+                    dataKey="label"
+                    axisLine={false}
+                    tickLine={false}
+                    tick={{ fontSize: 9, fill: '#94a3b8' }}
+                    interval="preserveStartEnd"
+                  />
+                  <Tooltip content={<CustomTooltip />} />
+                  <Area
+                    type="monotone"
+                    dataKey="value"
+                    stroke="#6366f1"
+                    strokeWidth={2}
+                    fill={`url(#btn-gradient-${button.id})`}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ButtonClickList({ title, buttons, icon }: ButtonClickListProps) {
+  const maxCount = Math.max(...buttons.map(b => b.count), 1);
+  const sortedButtons = [...buttons].sort((a, b) => b.count - a.count);
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-2xl p-6 shadow-sm">
+      <div className="flex items-center gap-3 mb-6">
+        {icon && <div className="p-2 bg-indigo-50 rounded-lg text-indigo-600">{icon}</div>}
+        <h3 className="font-semibold text-slate-900">{title}</h3>
+      </div>
+      <div className="space-y-2">
+        {sortedButtons.map((button) => (
+          <ButtonRow key={button.id} button={button} maxCount={maxCount} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/KPICard.tsx
+++ b/src/components/dashboard/KPICard.tsx
@@ -1,0 +1,71 @@
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+
+interface KPICardProps {
+  title: string;
+  value: number;
+  icon?: React.ReactNode;
+  trend?: {
+    value: number;
+    label: string;
+  };
+  variant?: 'default' | 'primary';
+}
+
+export function KPICard({ title, value, icon, trend, variant = 'default' }: KPICardProps) {
+  const getTrendColor = (trendValue: number) => {
+    if (trendValue > 0) return 'text-emerald-600 bg-emerald-50';
+    if (trendValue < 0) return 'text-red-600 bg-red-50';
+    return 'text-slate-500 bg-slate-100';
+  };
+
+  const getTrendIcon = (trendValue: number) => {
+    if (trendValue > 0) return <TrendingUp className="w-3 h-3" />;
+    if (trendValue < 0) return <TrendingDown className="w-3 h-3" />;
+    return <Minus className="w-3 h-3" />;
+  };
+
+  const formatTrendValue = (trendValue: number) => {
+    const sign = trendValue > 0 ? '+' : '';
+    return `${sign}${trendValue}%`;
+  };
+
+  if (variant === 'primary') {
+    return (
+      <div className="bg-gradient-to-br from-indigo-600 to-indigo-700 rounded-2xl p-6 text-white shadow-lg">
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-indigo-100 font-medium text-sm">{title}</span>
+          {icon && <div className="text-indigo-200">{icon}</div>}
+        </div>
+        <div className="text-4xl font-bold mb-2">{value.toLocaleString('no-NO')}</div>
+        {trend && (
+          <div className="flex items-center gap-2">
+            <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-full bg-white/20`}>
+              {getTrendIcon(trend.value)}
+              {formatTrendValue(trend.value)}
+            </span>
+            <span className="text-indigo-200 text-xs">{trend.label}</span>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition-shadow">
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-slate-500 font-medium text-sm">{title}</span>
+        {icon && <div className="text-slate-400">{icon}</div>}
+      </div>
+      <div className="text-3xl font-bold text-slate-900 mb-2">{value.toLocaleString('no-NO')}</div>
+      {trend && (
+        <div className="flex items-center gap-2">
+          <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-full ${getTrendColor(trend.value)}`}>
+            {getTrendIcon(trend.value)}
+            {formatTrendValue(trend.value)}
+          </span>
+          <span className="text-slate-400 text-xs">{trend.label}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/TrafficChart.tsx
+++ b/src/components/dashboard/TrafficChart.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Globe, Users, Eye } from 'lucide-react';
+
+interface PageStats {
+  label: string;
+  totalViews: number;
+  totalVisitors: number;
+  todayVisitors: number;
+}
+
+interface TrafficChartProps {
+  pageId: string;
+  stats: PageStats;
+}
+
+type Period = '24h' | 'week' | 'month' | 'year';
+
+interface TimeseriesPoint {
+  label: string;
+  value: number;
+}
+
+const PERIOD_OPTIONS: { value: Period; label: string }[] = [
+  { value: '24h', label: '24t' },
+  { value: 'week', label: 'Uke' },
+  { value: 'month', label: 'Måned' },
+  { value: 'year', label: 'År' },
+];
+
+export function TrafficChart({ pageId, stats }: TrafficChartProps) {
+  const [period, setPeriod] = useState<Period>('week');
+  const [data, setData] = useState<TimeseriesPoint[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/pageview?timeseries=true&pageId=${pageId}&period=${period}`);
+      const result = await response.json();
+      if (result.timeseries) {
+        setData(result.timeseries);
+      }
+    } catch (error) {
+      console.error('Error fetching chart data:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [pageId, period]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: Array<{ value: number }>; label?: string }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white border border-slate-200 rounded-lg shadow-lg px-3 py-2">
+          <p className="text-xs text-slate-500 mb-1">{label}</p>
+          <p className="text-sm font-semibold text-slate-900">{payload[0].value} visninger</p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-2xl p-6 shadow-sm">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-blue-50 rounded-lg">
+            <Globe className="w-5 h-5 text-blue-600" />
+          </div>
+          <h3 className="font-semibold text-slate-900">{stats.label}</h3>
+        </div>
+        <div className="flex gap-1 bg-slate-100 rounded-lg p-1">
+          {PERIOD_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              onClick={() => setPeriod(option.value)}
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-all ${
+                period === option.value
+                  ? 'bg-white text-slate-900 shadow-sm'
+                  : 'text-slate-500 hover:text-slate-700'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 mb-6">
+        <div className="text-center p-4 bg-slate-50 rounded-xl">
+          <div className="flex justify-center mb-2">
+            <Eye className="w-4 h-4 text-slate-400" />
+          </div>
+          <div className="text-2xl font-bold text-slate-900">{stats.totalViews.toLocaleString('no-NO')}</div>
+          <div className="text-xs text-slate-500 uppercase tracking-wide mt-1">Visninger</div>
+        </div>
+        <div className="text-center p-4 bg-slate-50 rounded-xl">
+          <div className="flex justify-center mb-2">
+            <Users className="w-4 h-4 text-slate-400" />
+          </div>
+          <div className="text-2xl font-bold text-slate-900">{stats.totalVisitors.toLocaleString('no-NO')}</div>
+          <div className="text-xs text-slate-500 uppercase tracking-wide mt-1">Unike</div>
+        </div>
+        <div className="text-center p-4 bg-blue-50 rounded-xl">
+          <div className="flex justify-center mb-2">
+            <Users className="w-4 h-4 text-blue-500" />
+          </div>
+          <div className="text-2xl font-bold text-blue-600">{stats.todayVisitors}</div>
+          <div className="text-xs text-slate-500 uppercase tracking-wide mt-1">I dag</div>
+        </div>
+      </div>
+
+      <div className="h-48">
+        {loading ? (
+          <div className="h-full flex items-center justify-center text-slate-400">
+            <div className="animate-pulse">Laster...</div>
+          </div>
+        ) : data.length === 0 ? (
+          <div className="h-full flex items-center justify-center text-slate-400">
+            Ingen data ennå
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={data} margin={{ top: 5, right: 5, left: -20, bottom: 5 }}>
+              <defs>
+                <linearGradient id={`gradient-${pageId}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
+                  <stop offset="100%" stopColor="#3b82f6" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <XAxis
+                dataKey="label"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 10, fill: '#94a3b8' }}
+                interval="preserveStartEnd"
+              />
+              <YAxis hide />
+              <Tooltip content={<CustomTooltip />} />
+              <Area
+                type="monotone"
+                dataKey="value"
+                stroke="#3b82f6"
+                strokeWidth={2}
+                fill={`url(#gradient-${pageId})`}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,0 +1,4 @@
+export { AnalyticsDashboard } from './AnalyticsDashboard';
+export { KPICard } from './KPICard';
+export { TrafficChart } from './TrafficChart';
+export { ButtonClickList } from './ButtonClickList';

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -3,6 +3,11 @@ export const prerender = false;
 
 import { TRACKED_BUTTONS } from './api/track';
 import { TRACKED_PAGES } from './api/pageview';
+import { AnalyticsDashboard } from '../components/dashboard';
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import '@fontsource/inter/700.css';
 
 // Get the secret token from environment
 const cloudflareEnv = Astro.locals.runtime?.env;
@@ -67,10 +72,6 @@ if (hasAccess) {
     }
   }
 }
-
-// Group buttons by page
-const okrButtons = ['okr_submit', 'okr_example', 'okr_reset', 'okr_privacy_toggle', 'okr_copy_suggestion', 'okr_read_more'];
-const landingButtons = ['hero_cta', 'tools_okr_cta', 'contact_email', 'contact_linkedin', 'about_linkedin'];
 ---
 
 <!DOCTYPE html>
@@ -80,546 +81,53 @@ const landingButtons = ['hero_cta', 'tools_okr_cta', 'contact_email', 'contact_l
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" type="image/svg+xml" href="/fyrk-monogram-primary-navy.svg" />
-  <title>Stats - FYRK</title>
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      font-family: system-ui, -apple-system, sans-serif;
-      background: #f5f5f5;
-      min-height: 100vh;
-      padding: 20px;
+  <title>Analytics - FYRK</title>
+  <style is:global>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
     }
-    .container {
-      max-width: 900px;
-      margin: 0 auto;
-    }
-    .header {
-      text-align: center;
-      margin-bottom: 32px;
-    }
-    h1 { color: #1e3a5f; margin-bottom: 8px; font-size: 1.75rem; }
-    .subtitle { color: #666; font-size: 0.9rem; }
-    .card {
-      background: white;
-      border-radius: 12px;
-      padding: 24px;
-      box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-      margin-bottom: 24px;
-    }
-    .error-card {
-      border: 2px solid #ef4444;
-      text-align: center;
-      max-width: 400px;
-      margin: 100px auto;
-    }
-    .section-title {
-      color: #1e3a5f;
-      font-size: 1.1rem;
-      font-weight: 600;
-      margin-bottom: 16px;
-      padding-bottom: 8px;
-      border-bottom: 2px solid #e5e7eb;
-    }
-    .stats-grid {
-      display: grid;
-      gap: 12px;
-    }
-    .stat-row {
-      background: #f9fafb;
-      border-radius: 8px;
-      overflow: hidden;
-    }
-    .stat-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 12px 16px;
-      transition: background 0.2s;
-    }
-    .stat-header:hover {
-      background: #f3f4f6;
-    }
-    .stat-label {
-      color: #374151;
-      font-size: 0.95rem;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-    .stat-count {
-      font-weight: 600;
-      color: #1e3a5f;
-      font-size: 1.1rem;
-      min-width: 60px;
-      text-align: right;
-    }
-    .chart-toggle {
-      background: none;
-      border: 1px solid #d1d5db;
-      border-radius: 4px;
-      padding: 4px 8px;
-      font-size: 0.75rem;
-      color: #6b7280;
-      cursor: pointer;
-      transition: all 0.2s;
-    }
-    .chart-toggle:hover {
-      background: #e5e7eb;
-    }
-    .chart-toggle.active {
-      background: #1e3a5f;
-      color: white;
-      border-color: #1e3a5f;
-    }
-    .chart-container {
-      padding: 16px;
-      background: #fff;
-      border-top: 1px solid #e5e7eb;
-      display: none;
-    }
-    .chart-container.visible {
-      display: block;
-    }
-    .mini-chart {
-      height: 80px;
-      width: 100%;
-      display: block;
-    }
-    .period-selector {
-      display: flex;
-      gap: 4px;
-      margin-bottom: 12px;
-    }
-    .period-btn {
-      background: #f3f4f6;
-      border: none;
-      border-radius: 4px;
-      padding: 4px 10px;
-      font-size: 0.75rem;
-      color: #6b7280;
-      cursor: pointer;
-      transition: all 0.2s;
-    }
-    .period-btn:hover {
-      background: #e5e7eb;
-    }
-    .period-btn.active {
-      background: #1e3a5f;
-      color: white;
-    }
-    .total-section {
-      background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
-      color: white;
-    }
-    .total-row {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 16px;
-    }
-    .total-label {
-      font-size: 1.1rem;
-    }
-    .total-count {
-      font-size: 2.5rem;
-      font-weight: 700;
-    }
-    .visitors-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 16px;
-    }
-    .visitor-card {
-      background: #f9fafb;
-      border-radius: 8px;
-      padding: 16px;
-    }
-    .visitor-card-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 12px;
-    }
-    .visitor-page-label {
-      font-size: 0.9rem;
-      color: #374151;
-      font-weight: 600;
-    }
-    .visitor-stats {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 8px;
-      text-align: center;
-    }
-    .visitor-stat {
-      padding: 10px 8px;
-      background: white;
-      border-radius: 6px;
-    }
-    .visitor-stat-value {
-      font-size: 1.4rem;
-      font-weight: 600;
-      color: #1e3a5f;
-    }
-    .visitor-stat-label {
-      font-size: 0.7rem;
-      color: #9ca3af;
-      text-transform: uppercase;
-      margin-top: 2px;
-    }
-    .visitor-chart-container {
-      margin-top: 12px;
-      padding-top: 12px;
-      border-top: 1px solid #e5e7eb;
-      display: none;
-    }
-    .visitor-chart-container.visible {
-      display: block;
-    }
-    .refresh {
-      text-align: center;
-      color: #666;
-      font-size: 0.85rem;
-      margin-top: 16px;
-    }
-    .refresh a {
-      color: #1e3a5f;
-      text-decoration: underline;
-    }
-    .not-configured {
-      color: #f59e0b;
-      font-size: 0.9rem;
-      text-align: center;
-      padding: 40px;
-    }
-    .error { color: #ef4444; }
-    .zero-count {
-      color: #9ca3af;
-    }
-    .chart-loading {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 80px;
-      color: #9ca3af;
-      font-size: 0.85rem;
-    }
-    .chart-area {
-      fill: rgba(30, 58, 95, 0.1);
-    }
-    .chart-line {
-      fill: none;
-      stroke: #1e3a5f;
-      stroke-width: 2;
-      stroke-linecap: round;
-      stroke-linejoin: round;
-    }
-    .chart-labels {
-      display: flex;
-      justify-content: space-between;
-      font-size: 0.65rem;
-      color: #9ca3af;
-      margin-top: 4px;
-      padding: 0 4px;
-    }
-    .no-data {
-      text-align: center;
-      padding: 20px;
-      color: #9ca3af;
-      font-size: 0.85rem;
+    html {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
     }
   </style>
 </head>
 <body>
   {!hasAccess ? (
-    <div class="card error-card">
-      <h1 class="error">Ingen tilgang</h1>
-      <p>Ugyldig eller manglende token.</p>
-    </div>
-  ) : (
-    <div class="container">
-      <div class="header">
-        <h1>FYRK Statistikk</h1>
-        <p class="subtitle">Klikkstatistikk og besøkende</p>
-      </div>
-
-      {buttonCounts !== null && pageStats !== null ? (
-        <>
-          <!-- Total summary -->
-          <div class="card total-section">
-            <div class="total-row">
-              <span class="total-label">Totalt antall knappeklikk</span>
-              <span class="total-count">{totalClicks}</span>
-            </div>
-          </div>
-
-          <!-- Page visitors -->
-          <div class="card">
-            <h2 class="section-title">Sidevisninger og besøkende</h2>
-            <div class="visitors-grid">
-              {Object.entries(pageStats).map(([id, stats]) => (
-                <div class="visitor-card">
-                  <div class="visitor-card-header">
-                    <span class="visitor-page-label">{stats.label}</span>
-                    <button class="chart-toggle" data-chart-page={id}>📊</button>
-                  </div>
-                  <div class="visitor-stats">
-                    <div class="visitor-stat">
-                      <div class="visitor-stat-value">{stats.totalViews}</div>
-                      <div class="visitor-stat-label">Visninger</div>
-                    </div>
-                    <div class="visitor-stat">
-                      <div class="visitor-stat-value">{stats.totalVisitors}</div>
-                      <div class="visitor-stat-label">Unike</div>
-                    </div>
-                    <div class="visitor-stat">
-                      <div class="visitor-stat-value">{stats.todayVisitors}</div>
-                      <div class="visitor-stat-label">I dag</div>
-                    </div>
-                  </div>
-                  <div class="visitor-chart-container" id={`page-chart-${id}`}>
-                    <div class="period-selector">
-                      <button class="period-btn active" data-period="24h">24t</button>
-                      <button class="period-btn" data-period="week">Uke</button>
-                      <button class="period-btn" data-period="month">Måned</button>
-                      <button class="period-btn" data-period="year">År</button>
-                    </div>
-                    <div class="chart-content">
-                      <div class="chart-loading">Laster...</div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <!-- OKR-sjekken page -->
-          <div class="card">
-            <h2 class="section-title">OKR-sjekken</h2>
-            <div class="stats-grid">
-              {okrButtons.map((id) => (
-                <div class="stat-row">
-                  <div class="stat-header">
-                    <span class="stat-label">
-                      {buttonCounts[id]?.label || id}
-                      <button class="chart-toggle" data-chart-btn={id}>📊</button>
-                    </span>
-                    <span class={`stat-count ${buttonCounts[id]?.count === 0 ? 'zero-count' : ''}`}>
-                      {buttonCounts[id]?.count || 0}
-                    </span>
-                  </div>
-                  <div class="chart-container" id={`btn-chart-${id}`}>
-                    <div class="period-selector">
-                      <button class="period-btn active" data-period="24h">24t</button>
-                      <button class="period-btn" data-period="week">Uke</button>
-                      <button class="period-btn" data-period="month">Måned</button>
-                      <button class="period-btn" data-period="year">År</button>
-                    </div>
-                    <div class="chart-content">
-                      <div class="chart-loading">Laster...</div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <!-- Landing page -->
-          <div class="card">
-            <h2 class="section-title">Landingsside</h2>
-            <div class="stats-grid">
-              {landingButtons.map((id) => (
-                <div class="stat-row">
-                  <div class="stat-header">
-                    <span class="stat-label">
-                      {buttonCounts[id]?.label || id}
-                      <button class="chart-toggle" data-chart-btn={id}>📊</button>
-                    </span>
-                    <span class={`stat-count ${buttonCounts[id]?.count === 0 ? 'zero-count' : ''}`}>
-                      {buttonCounts[id]?.count || 0}
-                    </span>
-                  </div>
-                  <div class="chart-container" id={`btn-chart-${id}`}>
-                    <div class="period-selector">
-                      <button class="period-btn active" data-period="24h">24t</button>
-                      <button class="period-btn" data-period="week">Uke</button>
-                      <button class="period-btn" data-period="month">Måned</button>
-                      <button class="period-btn" data-period="year">År</button>
-                    </div>
-                    <div class="chart-content">
-                      <div class="chart-loading">Laster...</div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <p class="refresh">
-            <a href={`/stats?token=${providedToken}`}>Oppdater</a> · Sist oppdatert: {new Date().toLocaleString('no-NO')}
-          </p>
-        </>
-      ) : (
-        <div class="card">
-          <p class="not-configured">KV ikke konfigurert</p>
+    <div class="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+      <div class="bg-white border border-red-200 rounded-2xl p-8 text-center max-w-md shadow-lg">
+        <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg class="w-8 h-8 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
         </div>
-      )}
+        <h1 class="text-xl font-bold text-slate-900 mb-2">Ingen tilgang</h1>
+        <p class="text-slate-500">Ugyldig eller manglende token.</p>
+      </div>
+    </div>
+  ) : buttonCounts !== null && pageStats !== null ? (
+    <AnalyticsDashboard
+      client:load
+      buttonCounts={buttonCounts}
+      pageStats={pageStats}
+      totalClicks={totalClicks}
+      refreshToken={providedToken || ''}
+    />
+  ) : (
+    <div class="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+      <div class="bg-white border border-amber-200 rounded-2xl p-8 text-center max-w-md shadow-lg">
+        <div class="w-16 h-16 bg-amber-100 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg class="w-8 h-8 text-amber-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+        </div>
+        <h1 class="text-xl font-bold text-slate-900 mb-2">KV ikke konfigurert</h1>
+        <p class="text-slate-500">Analytics storage er ikke satt opp.</p>
+      </div>
     </div>
   )}
-
-  <script>
-    // Chart rendering utility
-    function renderMiniChart(container: HTMLElement, data: {label: string, value: number}[]) {
-      if (!data || data.length === 0) {
-        container.innerHTML = '<div class="no-data">Ingen data ennå</div>';
-        return;
-      }
-
-      const width = container.clientWidth || 300;
-      const height = 80;
-      const padding = { top: 10, right: 10, bottom: 10, left: 10 };
-
-      const values = data.map(d => d.value);
-      const maxValue = Math.max(...values, 1);
-
-      const chartWidth = width - padding.left - padding.right;
-      const chartHeight = height - padding.top - padding.bottom;
-
-      // Calculate points
-      const points = data.map((d, i) => {
-        const x = padding.left + (i / (data.length - 1 || 1)) * chartWidth;
-        const y = padding.top + chartHeight - (d.value / maxValue) * chartHeight;
-        return { x, y, label: d.label, value: d.value };
-      });
-
-      // Create SVG path for line
-      const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
-
-      // Create SVG path for area
-      const areaPath = `${linePath} L ${points[points.length - 1].x} ${padding.top + chartHeight} L ${points[0].x} ${padding.top + chartHeight} Z`;
-
-      // Get labels for x-axis
-      const firstLabel = data[0].label;
-      const lastLabel = data[data.length - 1].label;
-
-      container.innerHTML = `
-        <svg class="mini-chart" viewBox="0 0 ${width} ${height}" preserveAspectRatio="xMidYMid meet">
-          <path class="chart-area" d="${areaPath}" />
-          <path class="chart-line" d="${linePath}" />
-        </svg>
-        <div class="chart-labels">
-          <span>${firstLabel}</span>
-          <span>${lastLabel}</span>
-        </div>
-      `;
-    }
-
-    // Fetch and render chart data
-    async function loadChartData(type: string, id: string, period: string, container: HTMLElement) {
-      const chartContent = container.querySelector('.chart-content') as HTMLElement;
-      if (!chartContent) return;
-
-      chartContent.innerHTML = '<div class="chart-loading">Laster...</div>';
-
-      try {
-        let url: string;
-        if (type === 'button') {
-          url = `/api/track?timeseries=true&buttonId=${id}&period=${period}`;
-        } else {
-          url = `/api/pageview?timeseries=true&pageId=${id}&period=${period}`;
-        }
-
-        const response = await fetch(url);
-        const data = await response.json();
-
-        if (data.timeseries && data.timeseries.length > 0) {
-          renderMiniChart(chartContent, data.timeseries);
-        } else {
-          chartContent.innerHTML = '<div class="no-data">Ingen data ennå</div>';
-        }
-      } catch (error) {
-        console.error('Error loading chart:', error);
-        chartContent.innerHTML = '<div class="no-data">Kunne ikke laste data</div>';
-      }
-    }
-
-    // Initialize all event listeners when DOM is ready
-    function initializeStats() {
-      // Initialize button chart toggles
-      document.querySelectorAll<HTMLButtonElement>('.chart-toggle[data-chart-btn]').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          const buttonId = btn.dataset.chartBtn;
-          if (!buttonId) return;
-          const container = document.getElementById(`btn-chart-${buttonId}`);
-          if (!container) return;
-
-          if (container.classList.contains('visible')) {
-            container.classList.remove('visible');
-            btn.classList.remove('active');
-          } else {
-            container.classList.add('visible');
-            btn.classList.add('active');
-            const activePeriod = container.querySelector<HTMLButtonElement>('.period-btn.active')?.dataset.period || '24h';
-            loadChartData('button', buttonId, activePeriod, container);
-          }
-        });
-      });
-
-      // Initialize page chart toggles
-      document.querySelectorAll<HTMLButtonElement>('.chart-toggle[data-chart-page]').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          const pageId = btn.dataset.chartPage;
-          if (!pageId) return;
-          const container = document.getElementById(`page-chart-${pageId}`);
-          if (!container) return;
-
-          if (container.classList.contains('visible')) {
-            container.classList.remove('visible');
-            btn.classList.remove('active');
-          } else {
-            container.classList.add('visible');
-            btn.classList.add('active');
-            const activePeriod = container.querySelector<HTMLButtonElement>('.period-btn.active')?.dataset.period || '24h';
-            loadChartData('page', pageId, activePeriod, container);
-          }
-        });
-      });
-
-      // Initialize period selectors
-      document.querySelectorAll('.period-selector').forEach(selector => {
-        selector.querySelectorAll<HTMLButtonElement>('.period-btn').forEach(btn => {
-          btn.addEventListener('click', () => {
-            // Update active state
-            selector.querySelectorAll('.period-btn').forEach(b => b.classList.remove('active'));
-            btn.classList.add('active');
-
-            const period = btn.dataset.period;
-            if (!period) return;
-            const container = selector.parentElement as HTMLElement;
-            if (!container) return;
-
-            // Determine if this is a button or page chart
-            const containerId = container.id;
-            if (containerId.startsWith('btn-chart-')) {
-              const buttonId = containerId.replace('btn-chart-', '');
-              loadChartData('button', buttonId, period, container);
-            } else if (containerId.startsWith('page-chart-')) {
-              const pageId = containerId.replace('page-chart-', '');
-              loadChartData('page', pageId, period, container);
-            }
-          });
-        });
-      });
-    }
-
-    // Run initialization when DOM is ready
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', initializeStats);
-    } else {
-      initializeStats();
-    }
-  </script>
 </body>
 </html>


### PR DESCRIPTION
Replace the existing stats page with a professional SaaS-style analytics dashboard featuring:

- KPI cards with primary/secondary variants and trend indicators
- Interactive area charts using Recharts for traffic visualization
- Horizontal bar progress visualizations for button click statistics
- Modern toggle-group time range selectors (24h, Week, Month, Year)
- Expandable detail views with mini-charts for each metric
- Responsive grid layout (1-4 columns based on viewport)
- Inter font with proper weight variants
- Slate/Indigo color palette with gradient accents
- Lucide icons throughout for consistent iconography

Components created:
- KPICard: Primary metric display with optional trends
- TrafficChart: Page views with area chart and metric grid
- ButtonClickList: Sorted click stats with progress bar fills
- AnalyticsDashboard: Main container orchestrating all components