### PR TITLE
Fix smoke test failures

### DIFF
--- a/src/components/landing/ExperienceSection.astro
+++ b/src/components/landing/ExperienceSection.astro
@@ -33,7 +33,7 @@ const { title, summary, expandButtonText, collapseButtonText, experiences } = As
     <div class="experience-expandable">
       <button
         type="button"
-        class="experience-toggle mx-auto flex items-center gap-2 text-brand-navy font-medium hover:text-brand-navy/80 transition-colors"
+        class="experience-toggle mx-auto flex items-center justify-center gap-2 min-h-[48px] px-4 text-brand-navy font-medium hover:text-brand-navy/80 transition-colors"
         aria-expanded="false"
         aria-controls="experience-details"
       >

--- a/src/components/landing/LandingHeader.astro
+++ b/src/components/landing/LandingHeader.astro
@@ -35,7 +35,7 @@ const { navLinks } = Astro.props;
     <!-- Mobile menu button -->
     <button
       id={ELEMENT_IDS.MOBILE_MENU_BUTTON}
-      class="md:hidden p-2 text-neutral-700"
+      class="md:hidden p-3 min-h-[48px] min-w-[48px] flex items-center justify-center text-neutral-700"
       aria-label="Åpne meny"
       aria-expanded="false"
       aria-controls={ELEMENT_IDS.MOBILE_MENU}

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -15,7 +15,7 @@ import { mainNavigation } from '../../data/navigation';
       <!-- Mobile menu button -->
       <button
         id="mobile-menu-button"
-        class="md:hidden p-2 text-brand-navy dark:text-white focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 rounded-md transition-colors duration-fast"
+        class="md:hidden p-3 min-h-[48px] min-w-[48px] flex items-center justify-center text-brand-navy dark:text-white focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 rounded-md transition-colors duration-fast"
         aria-label="Åpne meny"
         aria-expanded="false"
         aria-controls="mobile-menu"


### PR DESCRIPTION
Mobile menu buttons and experience toggle button had insufficient touch target sizes (around 40px height) due to small padding. Added min-h-[48px] and min-w-[48px] classes to ensure all buttons meet WCAG 2.1 AA enhanced touch target requirements.