### PR TITLE
Build privacy-first analytics without cookies

### DIFF
--- a/src/components/OKRResultDisplay.tsx
+++ b/src/components/OKRResultDisplay.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { parseOKRResult, getScoreColor } from '../utils/okr-parser';
-import { CheckIcon, WarningIcon, LightbulbIcon, CopyIcon } from './ui/Icon';
+import { CheckIcon, WarningIcon, LightbulbIcon, CopyIcon, ThumbsUpIcon, ThumbsDownIcon } from './ui/Icon';
 import { cn } from '../utils/classes';
 import { trackClick } from '../utils/tracking';
 
@@ -202,6 +202,75 @@ function SuggestionBox({ suggestion, isStreaming }: { suggestion: string; isStre
 }
 
 /**
+ * Feedback buttons for user satisfaction tracking
+ */
+function FeedbackButtons({ isStreaming }: { isStreaming: boolean }) {
+  const [feedbackGiven, setFeedbackGiven] = useState<'up' | 'down' | null>(null);
+
+  if (isStreaming) {
+    return null;
+  }
+
+  const handleFeedback = (type: 'up' | 'down') => {
+    if (feedbackGiven) return; // Already gave feedback
+    setFeedbackGiven(type);
+    trackClick(type === 'up' ? 'feedback_up' : 'feedback_down');
+  };
+
+  if (feedbackGiven) {
+    return (
+      <div className="mt-6 pt-4 border-t border-neutral-200">
+        <p className="text-sm text-neutral-500 text-center">
+          Takk for tilbakemeldingen!
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-6 pt-4 border-t border-neutral-200">
+      <div className="flex items-center justify-center gap-4">
+        <span className="text-sm text-neutral-600">Var dette nyttig?</span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => handleFeedback('up')}
+            className={cn(
+              'inline-flex items-center gap-1.5 px-3 py-1.5',
+              'text-sm font-medium text-neutral-600',
+              'bg-neutral-100 hover:bg-feedback-success/10 hover:text-feedback-success',
+              'rounded-lg border border-neutral-200 hover:border-feedback-success/30',
+              'transition-colors focus:outline-none',
+              'focus:ring-2 focus:ring-brand-cyan-darker focus:ring-offset-2'
+            )}
+            aria-label="Ja, dette var nyttig"
+          >
+            <ThumbsUpIcon className="w-4 h-4" />
+            Ja
+          </button>
+          <button
+            type="button"
+            onClick={() => handleFeedback('down')}
+            className={cn(
+              'inline-flex items-center gap-1.5 px-3 py-1.5',
+              'text-sm font-medium text-neutral-600',
+              'bg-neutral-100 hover:bg-feedback-error/10 hover:text-feedback-error',
+              'rounded-lg border border-neutral-200 hover:border-feedback-error/30',
+              'transition-colors focus:outline-none',
+              'focus:ring-2 focus:ring-brand-cyan-darker focus:ring-offset-2'
+            )}
+            aria-label="Nei, dette var ikke nyttig"
+          >
+            <ThumbsDownIcon className="w-4 h-4" />
+            Nei
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
  * Collapsible section for detailed summary
  */
 function SummarySection({ summary, isStreaming }: { summary: string; isStreaming: boolean }) {
@@ -285,6 +354,9 @@ export default function OKRResultDisplay({ result, isStreaming }: OKRResultDispl
 
       {/* Suggestion box */}
       <SuggestionBox suggestion={parsed.suggestion} isStreaming={isStreaming} />
+
+      {/* Feedback buttons */}
+      <FeedbackButtons isStreaming={isStreaming} />
 
       {/* Streaming raw fallback when parsing fails */}
       {isStreaming && !parsed.score && !parsed.strengths.length && !parsed.improvements.length && result && (

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -59,6 +59,14 @@ const STROKE_ICON_PATHS = {
     viewBox: '0 0 24 24',
     d: 'M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z',
   },
+  thumbsUp: {
+    viewBox: '0 0 24 24',
+    d: 'M14 9V5a3 3 0 00-3-3l-4 9v11h11.28a2 2 0 002-1.7l1.38-9a2 2 0 00-2-2.3H14zM7 22H4a2 2 0 01-2-2v-7a2 2 0 012-2h3',
+  },
+  thumbsDown: {
+    viewBox: '0 0 24 24',
+    d: 'M10 15V19a3 3 0 003 3l4-9V2H5.72a2 2 0 00-2 1.7l-1.38 9a2 2 0 002 2.3H10zM17 2h2.67A2.31 2.31 0 0122 4v7a2.31 2.31 0 01-2.33 2H17',
+  },
 } as const;
 
 export type IconName = keyof typeof ICON_PATHS;
@@ -138,6 +146,14 @@ export function CopyIcon({ className }: IconProps) {
 
 export function ChevronRightIcon({ className }: IconProps) {
   return <Icon name="chevronRight" className={className} />;
+}
+
+export function ThumbsUpIcon({ className }: IconProps) {
+  return <StrokeIcon name="thumbsUp" className={className} />;
+}
+
+export function ThumbsDownIcon({ className }: IconProps) {
+  return <StrokeIcon name="thumbsDown" className={className} />;
 }
 
 /**

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -1,7 +1,15 @@
 /**
  * Client-side tracking utilities
- * Centralized module for button click tracking
+ * Centralized module for button click tracking and event logging
  */
+
+/**
+ * Metadata for check_success events (no PII)
+ */
+export interface EventMetadata {
+  charCount?: number;
+  processingTimeMs?: number;
+}
 
 /**
  * Track button click (fire and forget)
@@ -12,6 +20,29 @@ export function trackClick(buttonId: string): void {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ buttonId }),
+  }).catch(() => {
+    // Silently ignore tracking errors - tracking should never block the user
+  });
+}
+
+/**
+ * Log an event with optional metadata (fire and forget)
+ * Use this for funnel events that may carry additional data
+ *
+ * @param eventType - Event identifier (e.g., 'check_success', 'feedback_up')
+ * @param metadata - Optional metadata (charCount, processingTimeMs) - NO PII
+ */
+export function logEvent(eventType: string, metadata?: EventMetadata): void {
+  const payload: { buttonId: string; metadata?: EventMetadata } = { buttonId: eventType };
+
+  if (metadata) {
+    payload.metadata = metadata;
+  }
+
+  fetch('/api/track', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
   }).catch(() => {
     // Silently ignore tracking errors - tracking should never block the user
   });


### PR DESCRIPTION
- Add check_success event tracking with metadata (charCount, processingTimeMs)
- Add feedback_up and feedback_down events for user satisfaction tracking
- Add logEvent helper to tracking utility for events with metadata
- Store aggregated metrics in KV (no PII, only counters and averages)
- Add feedback UI with thumbs up/down after OKR analysis results
- Track processing time and input length for quality insights