### PR TITLE
Add funnel & feedback section to analytics dashboard

### DIFF
--- a/src/components/dashboard/AnalyticsDashboard.tsx
+++ b/src/components/dashboard/AnalyticsDashboard.tsx
@@ -1,4 +1,4 @@
-import { MousePointer, Eye, Zap, BarChart3, ExternalLink, Sparkles } from 'lucide-react';
+import { MousePointer, Eye, Zap, BarChart3, ExternalLink, Sparkles, ThumbsUp, Activity } from 'lucide-react';
 import { KPICard } from './KPICard';
 import { TrafficChart } from './TrafficChart';
 import { ButtonClickList } from './ButtonClickList';
@@ -24,6 +24,7 @@ interface AnalyticsDashboardProps {
 
 const OKR_BUTTONS = ['okr_submit', 'okr_example', 'okr_reset', 'okr_privacy_toggle', 'okr_copy_suggestion', 'okr_read_more'];
 const LANDING_BUTTONS = ['hero_cta', 'tools_okr_cta', 'contact_email', 'contact_linkedin', 'about_linkedin'];
+const FUNNEL_EVENTS = ['check_success', 'feedback_up', 'feedback_down'];
 
 export function AnalyticsDashboard({ buttonCounts, pageStats, totalClicks, refreshToken }: AnalyticsDashboardProps) {
   const totalViews = Object.values(pageStats).reduce((sum, p) => sum + p.totalViews, 0);
@@ -41,6 +42,18 @@ export function AnalyticsDashboard({ buttonCounts, pageStats, totalClicks, refre
     label: buttonCounts[id]?.label || id,
     count: buttonCounts[id]?.count || 0,
   }));
+
+  const funnelData = FUNNEL_EVENTS.map(id => ({
+    id,
+    label: buttonCounts[id]?.label || id,
+    count: buttonCounts[id]?.count || 0,
+  }));
+
+  // Calculate satisfaction rate
+  const feedbackUp = buttonCounts['feedback_up']?.count || 0;
+  const feedbackDown = buttonCounts['feedback_down']?.count || 0;
+  const totalFeedback = feedbackUp + feedbackDown;
+  const satisfactionRate = totalFeedback > 0 ? Math.round((feedbackUp / totalFeedback) * 100) : null;
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -93,6 +106,15 @@ export function AnalyticsDashboard({ buttonCounts, pageStats, totalClicks, refre
               value={todayVisitors}
               icon={<Sparkles className="w-5 h-5" />}
             />
+            {satisfactionRate !== null && (
+              <KPICard
+                title="Tilfredshet"
+                value={`${satisfactionRate}%`}
+                subtitle={`${totalFeedback} svar`}
+                icon={<ThumbsUp className="w-5 h-5" />}
+                variant={satisfactionRate >= 70 ? 'success' : satisfactionRate >= 50 ? 'warning' : 'danger'}
+              />
+            )}
           </div>
         </section>
 
@@ -125,6 +147,21 @@ export function AnalyticsDashboard({ buttonCounts, pageStats, totalClicks, refre
               title="Landingsside"
               buttons={landingButtonData}
               icon={<ExternalLink className="w-5 h-5" />}
+            />
+          </div>
+        </section>
+
+        {/* Funnel & Feedback */}
+        <section>
+          <h2 className="text-lg font-semibold text-slate-900 mb-4 flex items-center gap-2">
+            <Activity className="w-5 h-5 text-slate-400" />
+            Funnel & Tilbakemeldinger
+          </h2>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <ButtonClickList
+              title="OKR-sjekk funnel"
+              buttons={funnelData}
+              icon={<ThumbsUp className="w-5 h-5" />}
             />
           </div>
         </section>

--- a/src/components/dashboard/KPICard.tsx
+++ b/src/components/dashboard/KPICard.tsx
@@ -2,16 +2,17 @@ import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
 
 interface KPICardProps {
   title: string;
-  value: number;
+  value: number | string;
+  subtitle?: string;
   icon?: React.ReactNode;
   trend?: {
     value: number;
     label: string;
   };
-  variant?: 'default' | 'primary';
+  variant?: 'default' | 'primary' | 'success' | 'warning' | 'danger';
 }
 
-export function KPICard({ title, value, icon, trend, variant = 'default' }: KPICardProps) {
+export function KPICard({ title, value, subtitle, icon, trend, variant = 'default' }: KPICardProps) {
   const getTrendColor = (trendValue: number) => {
     if (trendValue > 0) return 'text-emerald-600 bg-emerald-50';
     if (trendValue < 0) return 'text-red-600 bg-red-50';
@@ -50,13 +51,29 @@ export function KPICard({ title, value, icon, trend, variant = 'default' }: KPIC
     );
   }
 
+  const getVariantStyles = () => {
+    switch (variant) {
+      case 'success':
+        return 'bg-emerald-50 border-emerald-200 [&_.kpi-value]:text-emerald-700 [&_.kpi-icon]:text-emerald-500';
+      case 'warning':
+        return 'bg-amber-50 border-amber-200 [&_.kpi-value]:text-amber-700 [&_.kpi-icon]:text-amber-500';
+      case 'danger':
+        return 'bg-red-50 border-red-200 [&_.kpi-value]:text-red-700 [&_.kpi-icon]:text-red-500';
+      default:
+        return 'bg-white border-slate-200';
+    }
+  };
+
+  const formattedValue = typeof value === 'number' ? value.toLocaleString('no-NO') : value;
+
   return (
-    <div className="bg-white border border-slate-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition-shadow">
+    <div className={`border rounded-2xl p-6 shadow-sm hover:shadow-md transition-shadow ${getVariantStyles()}`}>
       <div className="flex items-center justify-between mb-4">
         <span className="text-slate-500 font-medium text-sm">{title}</span>
-        {icon && <div className="text-slate-400">{icon}</div>}
+        {icon && <div className="kpi-icon text-slate-400">{icon}</div>}
       </div>
-      <div className="text-3xl font-bold text-slate-900 mb-2">{value.toLocaleString('no-NO')}</div>
+      <div className="kpi-value text-3xl font-bold text-slate-900 mb-2">{formattedValue}</div>
+      {subtitle && <div className="text-sm text-slate-500">{subtitle}</div>}
       {trend && (
         <div className="flex items-center gap-2">
           <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-full ${getTrendColor(trend.value)}`}>


### PR DESCRIPTION
- Display check_success, feedback_up, feedback_down in new section
- Add satisfaction rate KPI card (percentage of thumbs up)
- Support success/warning/danger variants in KPICard
- Support string values and subtitle in KPICard