### PR TITLE
Polish Konseptspeilet page for MVP release

### DIFF
--- a/src/components/KonseptSpeil.tsx
+++ b/src/components/KonseptSpeil.tsx
@@ -159,10 +159,11 @@ export default function KonseptSpeil() {
     setResult(null);
     setError(null);
     setInput('');
-    // Return focus to textarea
+    // Scroll to top and focus textarea for clear "start fresh" signal
+    window.scrollTo({ top: 0, behavior: 'smooth' });
     setTimeout(() => {
       textareaRef.current?.focus();
-    }, 50);
+    }, 100);
   };
 
   const handleSubmit = async () => {

--- a/src/components/KonseptSpeilResultDisplay.tsx
+++ b/src/components/KonseptSpeilResultDisplay.tsx
@@ -69,21 +69,21 @@ export default function KonseptSpeilResultDisplay({
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       {/* Antagelser i teksten */}
       {parsed.antagelser.length > 0 && (
         <section>
-          <h3 className="text-base font-semibold text-neutral-800 mb-3">
+          <h3 className="text-lg font-semibold text-neutral-900 mb-4 tracking-tight">
             Antagelser i teksten
           </h3>
-          <ul className="space-y-2">
+          <ul className="space-y-3">
             {parsed.antagelser.map((antagelse, i) => (
               <li
                 key={i}
-                className="flex items-start gap-3 text-[15px] text-neutral-700 leading-relaxed"
+                className="flex items-start gap-3 text-[15px] text-neutral-700 leading-[1.7]"
               >
                 <span
-                  className="mt-2 w-1.5 h-1.5 rounded-full bg-brand-cyan-darker shrink-0"
+                  className="mt-[0.45rem] w-1.5 h-1.5 rounded-full bg-brand-cyan-darker shrink-0"
                   aria-hidden="true"
                 />
                 <span>{antagelse}</span>
@@ -91,7 +91,7 @@ export default function KonseptSpeilResultDisplay({
             ))}
           </ul>
           {isStreaming && parsed.sporsmal.length === 0 && (
-            <SpinnerIcon className="animate-spin h-4 w-4 text-neutral-400 mt-3" />
+            <SpinnerIcon className="animate-spin h-4 w-4 text-neutral-400 mt-4" />
           )}
         </section>
       )}
@@ -99,17 +99,17 @@ export default function KonseptSpeilResultDisplay({
       {/* Åpne spørsmål teksten reiser */}
       {parsed.sporsmal.length > 0 && (
         <section>
-          <h3 className="text-base font-semibold text-neutral-800 mb-3">
+          <h3 className="text-lg font-semibold text-neutral-900 mb-4 tracking-tight">
             Åpne spørsmål teksten reiser
           </h3>
-          <ul className="space-y-2">
+          <ul className="space-y-3">
             {parsed.sporsmal.map((sporsmal, i) => (
               <li
                 key={i}
-                className="flex items-start gap-3 text-[15px] text-neutral-700 leading-relaxed"
+                className="flex items-start gap-3 text-[15px] text-neutral-700 leading-[1.7]"
               >
                 <span
-                  className="mt-2 w-1.5 h-1.5 rounded-full bg-neutral-400 shrink-0"
+                  className="mt-[0.45rem] w-1.5 h-1.5 rounded-full bg-neutral-400 shrink-0"
                   aria-hidden="true"
                 />
                 <span>{sporsmal}</span>
@@ -117,7 +117,7 @@ export default function KonseptSpeilResultDisplay({
             ))}
           </ul>
           {isStreaming && (
-            <SpinnerIcon className="animate-spin h-4 w-4 text-neutral-400 mt-3" />
+            <SpinnerIcon className="animate-spin h-4 w-4 text-neutral-400 mt-4" />
           )}
         </section>
       )}

--- a/src/pages/api/konseptspeilet.ts
+++ b/src/pages/api/konseptspeilet.ts
@@ -26,21 +26,40 @@ Svar ALLTID på norsk (bokmål).
 - Anbefaler neste steg eller handlinger
 - Bruker konsulentspråk, rammeverk eller faguttrykk (med mindre brukeren eksplisitt nevner dem)
 - Forteller brukeren hva de "bør" eller "må" gjøre
+- Konkluderer eller trekker slutninger
+- Gir råd eller anbefalinger
 
-## SPRÅK OG TONE
-- Nøytral, rolig og ikke-dømmende
-- Bruk formuleringer som:
-  - "Teksten antyder at..."
-  - "Det kan ligge en antakelse om..."
-  - "Det virker som teksten forutsetter..."
-- Unngå evaluerende ord helt
+## SPRÅK OG TONE – STRENGT REFLEKTERENDE
+Bruk KUN reflekterende formuleringer. ALDRI assertive eller normative påstander.
+
+FORBUDTE formuleringer (bruk ALDRI disse):
+- "er" / "er ikke" som konklusjon
+- "kan" som anbefaling
+- "bør" / "må"
+- "er ikke showstoppere"
+- "er klart" / "er uklart"
+- "viktig" / "kritisk" / "essensielt"
+
+PÅKREVDE formuleringer (bruk ALLTID disse mønstrene):
+- "Teksten antyder at..."
+- "Det kan ligge en antakelse om at..."
+- "Det fremstår som om..."
+- "Det virker som teksten forutsetter..."
+- "Teksten synes å ta for gitt at..."
+
+EKSEMPEL på omskriving:
+FRA: "Usikkerhet om målgruppe og manglende testing er ikke showstoppere for å gå videre."
+TIL: "Teksten antyder at usikkerhet om målgruppe og manglende testing ikke oppleves som showstoppere."
+
+FRA: "Ideen kan fungere hvis..."
+TIL: "Teksten synes å forutsette at..."
 
 ## OUTPUT-FORMAT (OBLIGATORISK MARKDOWN)
 Returner KUN disse to seksjonene i ren Markdown. Ingen annen tekst før eller etter.
 
 ## Antagelser i teksten
 
-- [2–6 kulepunkter, formulert som observasjoner]
+- [2–6 kulepunkter, formulert som observasjoner med reflekterende språk]
 
 ## Åpne spørsmål teksten reiser
 


### PR DESCRIPTION
- Harden system prompt to enforce strictly reflective (non-advisory) language
  - Add explicit forbidden phrases list (er, kan, bør, showstoppere)
  - Add required reflective phrase patterns (teksten antyder, fremstår som)
  - Include example transformations for AI guidance

- Improve result typography for read-aloud use
  - Increase line-height from relaxed to 1.7
  - Add more spacing between bullet points (space-y-3)
  - Make section headers stronger (text-lg, tracking-tight)
  - Increase spacing between sections (space-y-8)

- Enhance "Start på nytt" UX
  - Clear textarea and results
  - Scroll to top of page
  - Focus textarea for clear "start fresh" signal