### PR TITLE
Fix timeout on concept mirror

### DIFF
--- a/src/components/KonseptSpeil.tsx
+++ b/src/components/KonseptSpeil.tsx
@@ -16,8 +16,8 @@ const EXAMPLE_KONSEPT = `Jeg vurderer å bygge et lite verktøy for team som sli
 const SUBMIT_THRESHOLD = 50;
 
 /** Timeout thresholds in milliseconds */
-const SLOW_TIMEOUT_MS = 8000;
-const HARD_TIMEOUT_MS = 20000;
+const SLOW_TIMEOUT_MS = 15000;  // 15 seconds - shows "slow" UI feedback
+const HARD_TIMEOUT_MS = 45000;  // 45 seconds - aborts request (higher than server's 30s timeout)
 
 /** Error types for logging */
 type ErrorType = 'timeout' | 'network' | 'invalid_output' | 'validation' | null;


### PR DESCRIPTION
- Add 30-second server-side timeout for Anthropic API fetch requests using AbortController (uses existing REQUEST_TIMEOUT_MS constant)
- Increase client-side timeout from 20s to 45s (above server timeout)
- Increase slow feedback threshold from 8s to 15s
- Add proper timeout error handling with Norwegian error messages
- Return 504 status code for server-side timeout errors

Fixes timeout issues where requests would hang indefinitely when Anthropic API is slow to respond.