### PR TITLE
Fix color contrast accessibility violation

### DIFF
--- a/src/components/KonseptSpeil.tsx
+++ b/src/components/KonseptSpeil.tsx
@@ -468,7 +468,7 @@ export default function KonseptSpeil() {
 
       {/* Privacy assurance - visible near CTA */}
       {!result && (
-        <p className="text-xs text-neutral-400 leading-relaxed">
+        <p className="text-xs text-neutral-500 leading-relaxed">
           Ingen lagring, ingen innlogging, ingen trening av AI på det du skriver.
         </p>
       )}


### PR DESCRIPTION
Change text-neutral-400 to text-neutral-500 for the privacy assurance paragraph to meet WCAG 2 AA minimum contrast ratio of 4.5:1.

Previous contrast ratio was 2.41:1, now approximately 4.7:1.