### PR TITLE
Fix error when enabling harder challenge slider

### DIFF
--- a/src/pages/api/konseptspeilet.ts
+++ b/src/pages/api/konseptspeilet.ts
@@ -328,7 +328,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
     // Check cache
     cacheManager.cleanup();
-    const cacheKey = await hashInput('konseptspeil:' + input);
+    const cacheKey = await hashInput('konseptspeil:' + trimmedInput + (challengeMode ? ':challenge' : ''));
     const cachedEntry = cacheManager.get(cacheKey);
 
     if (cachedEntry) {


### PR DESCRIPTION
The server-side cache key was missing the challengeMode flag, causing the API to return cached responses from normal mode when challenge mode was toggled. This created a mismatch with the client-side cache key format which correctly included the mode suffix.